### PR TITLE
Migrate to distroless base and update project labels.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
+
 builds:
   - main: ./cmd/mcbdd
     env:
@@ -9,39 +10,47 @@ builds:
       - windows
     goarch:
       - amd64
+
 archives:
-  - format: tar.gz
-    name_template: >-
+  - name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+    formats: ["tar.gz"] # Korrigiert: 'format' ist deprecated
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"] # Korrigiert: 'format' ist deprecated
+
 checksum:
   name_template: "checksums.txt"
+
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next" # Korrigiert: 'name_template' ist deprecated
+
 release:
   prerelease: auto
+
 changelog:
   sort: asc
   filters:
     exclude:
       - "^docs:"
       - "^test:"
+
 upx:
   - enabled: true
     goos: [linux]
     compress: best
     lzma: true
+
 dockers:
   - dockerfile: Containerfile
     image_templates:
-      - "ghcr.io/marco98/mailcow-birthday-daemon:{{ .Major }}"
-      - "ghcr.io/marco98/mailcow-birthday-daemon:{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/marco98/mailcow-birthday-daemon:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "ghcr.io/marco98/mailcow-birthday-daemon:latest"
+      # Wir nutzen 'tolower', um den Owner-Namen kleinzuschreiben
+      - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:{{ .Major }}"
+      - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:latest"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,16 +19,16 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    formats: ["tar.gz"] # Korrigiert: 'format' ist deprecated
+    formats: ["tar.gz"]
     format_overrides:
       - goos: windows
-        formats: ["zip"] # Korrigiert: 'format' ist deprecated
+        formats: ["zip"]
 
 checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  version_template: "{{ incpatch .Version }}-next" # Korrigiert: 'name_template' ist deprecated
+  version_template: "{{ incpatch .Version }}-next"
 
 release:
   prerelease: auto
@@ -49,7 +49,6 @@ upx:
 dockers:
   - dockerfile: Containerfile
     image_templates:
-      # Wir nutzen 'tolower', um den Owner-Namen kleinzuschreiben
       - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:{{ .Major }}"
       - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:{{ .Major }}.{{ .Minor }}"
       - "ghcr.io/{{ tolower .Env.GITHUB_REPOSITORY_OWNER }}/mailcow-birthday-daemon:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"

--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,9 @@
-FROM scratch
+FROM gcr.io/distroless/static-debian12
 
 LABEL org.opencontainers.image.source https://github.com/Marco98/mailcow-birthday-daemon
-ENTRYPOINT ["/mailcow-birthday-daemon"]
 
 ENV STATEFILE=/data/state.json
 VOLUME [ "/data" ]
 
 COPY mailcow-birthday-daemon /mailcow-birthday-daemon
+ENTRYPOINT ["/mailcow-birthday-daemon"]


### PR DESCRIPTION
# Description

This PR addresses issues with TLS certificate verification and improves the overall container security and portability.

## The Problem
When running the daemon in a `scratch`-based container, the application fails to verify HTTPS certificates (e.g., Let's Encrypt) for the Mailcow API, resulting in the following error:
`x509: certificate signed by unknown authority`

This occurs because the `scratch` image is completely empty and lacks the necessary Root CA certificates required by Go to validate secure TLS connections.

## The Solution
* **Container Migration**: Switched the base image from `scratch` to `gcr.io/distroless/static-debian12`.
* **Security & Reliability**: The Distroless base provides a minimal attack surface (no shell or package manager) while including essential `ca-certificates` and `tzdata`. This allows the daemon to verify TLS connections natively and ensures correct timezone handling for birthday events.
* **Portable CI/CD**: Refactored `.goreleaser.yaml` to use portable templates (`tolower .Env.GITHUB_REPOSITORY_OWNER`). This ensures that Docker builds work correctly for all forks and repository owners without hardcoding usernames.

## Changes
1. **Containerfile**: Migrated to distroless base and updated project labels.
2. **.goreleaser.yaml**: Updated Docker image templates to be owner-agnostic and migrated deprecated fields to the current GoReleaser v2 syntax.

---
*Note: This change ensures the application remains secure by allowing full X.509 verification instead of bypassing TLS checks.*