### PR TITLE
ci: auto-update README image tag on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,3 +39,15 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update README image tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          git fetch origin ${{ github.event.repository.default_branch }}
+          git checkout ${{ github.event.repository.default_branch }}
+          sed -i "s|mailcow-birthday-daemon:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*|mailcow-birthday-daemon:${VERSION}|g" README.md
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --cached --quiet || git commit -m "docs: update image tag to ${VERSION} [skip ci]"
+          git push origin ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## Summary

- Adds a post-release step to the release workflow that updates the image tag in `README.md` to match the newly published version
- Checks out the default branch before patching to avoid pushing from a detached HEAD
- Uses `[skip ci]` on the commit to prevent triggering another workflow run