### PR TITLE
docs: add Development section with go-task run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ The API-Key can be obtained in the admin panel at Configuration > Access > Edit 
 
 As the Mailcow API does not seem to be complete and looks more like a early access, i would strongly advice against enabling "Skip IP check for API".
 
+## Development
+
+The application can be run locally using [go-task](https://taskfile.dev):
+
+```sh
+go-task run
+```
+
+`go-task` will automatically load a `.env` file from the project root, so you can configure environment variables (e.g. `MAILCOW_BASE`, `MAILCOW_APIKEY`) there without exporting them manually.
+
 ## How it works
 
 - Via the mailcow API a app password with access to carddav and caldav in generated for every user


### PR DESCRIPTION
## Summary

- Adds a **Development** section to the README between the Installation and How it works sections
- Documents that developers can run the application locally with `go-task run`
- Notes that go-task automatically loads a `.env` file, making local configuration straightforward